### PR TITLE
fixed styling on actual mobile device

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- xxxxxxxxxxxxxxx -->
 <html lang="en">
     <head>
         <meta charset="UTF-8">

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,9 @@
 import React from "react";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 import App from "./App";
 import './style.css';
 
-ReactDOM.render(<App />, document.querySelector("#root"))
+const rootElement = document.querySelector("#root");
+const root = createRoot(rootElement);
+
+root.render(<App />);

--- a/src/style.css
+++ b/src/style.css
@@ -103,7 +103,7 @@ nav {
 }
 
 /* fit for different screens size */
-@media screen and (min-width: 1024px) {
+/* @media screen and (min-width: 1024px) {
     * {
         font-size: 100%;
     }
@@ -151,9 +151,11 @@ nav {
     }
 }
 
-@media screen and (max-width: 375px) {
+ */
+
+@media screen and (max-width: 280px) {
     * {
-        font-size: 35%;
+        font-size: 30%;
     }
     
     .card{
@@ -174,9 +176,9 @@ nav {
     }
 }
 
-@media screen and (max-width: 280px) {
+@media screen and (max-width: 375px) {
     * {
-        font-size: 30%;
+        font-size: 35%;
     }
     
     .card{

--- a/src/style.css
+++ b/src/style.css
@@ -199,7 +199,7 @@ nav {
 @media only screen 
   and (min-width: 375px) 
   and (max-width: 812px) 
-  and (-webkit-min-device-pixel-ratio: 3) { 
+  and (-webkit-min-device-pixel-ratio: 2) { 
     * {
         font-size: 35%;
     }
@@ -221,3 +221,26 @@ nav {
         width: 54rem;
     }
 }
+
+/* @media only screen and (max-width: 375px) {
+    * {
+        font-size: 35%;
+    }
+    
+    .card{
+        flex-direction: column;
+    }
+
+    .card--left {
+        margin-right: 0;
+    }
+
+    .card--left img {
+        width: 54rem;
+        height: 36rem;
+    }
+
+    .card--right {
+        width: 54rem;
+    }
+} */

--- a/src/style.css
+++ b/src/style.css
@@ -103,13 +103,13 @@ nav {
 }
 
 /* fit for different screens size */
-/* @media screen and (min-width: 1024px) {
+@media only screen and (min-width: 1024px) {
     * {
         font-size: 100%;
     }
 }
 
-@media screen and (max-width: 924px) {
+@media only screen and (max-width: 924px) {
     .card{
         flex-direction: column;
     }
@@ -128,7 +128,7 @@ nav {
     }
 }
 
-@media screen and (max-width: 540px) {
+@media only screen and (max-width: 540px) {
     * {
         font-size: 40%;
     }
@@ -151,9 +151,30 @@ nav {
     }
 }
 
- */
+@media only screen and (max-width: 375px) {
+    * {
+        font-size: 35%;
+    }
+    
+    .card{
+        flex-direction: column;
+    }
 
-/* @media screen and (max-width: 280px) {
+    .card--left {
+        margin-right: 0;
+    }
+
+    .card--left img {
+        width: 54rem;
+        height: 36rem;
+    }
+
+    .card--right {
+        width: 54rem;
+    }
+}
+
+@media only screen and (max-width: 280px) {
     * {
         font-size: 30%;
     }
@@ -175,26 +196,3 @@ nav {
         width: 54rem;
     }
 }
-
-@media screen and (max-width: 375px) {
-    * {
-        font-size: 35%;
-    }
-    
-    .card{
-        flex-direction: column;
-    }
-
-    .card--left {
-        margin-right: 0;
-    }
-
-    .card--left img {
-        width: 54rem;
-        height: 36rem;
-    }
-
-    .card--right {
-        width: 54rem;
-    }
-} */

--- a/src/style.css
+++ b/src/style.css
@@ -103,7 +103,7 @@ nav {
 }
 
 /* fit for different screens size */
-@media only screen and (min-width: 1024px) {
+/* @media only screen and (min-width: 1024px) {
     * {
         font-size: 100%;
     }
@@ -177,6 +177,31 @@ nav {
 @media only screen and (max-width: 280px) {
     * {
         font-size: 30%;
+    }
+    
+    .card{
+        flex-direction: column;
+    }
+
+    .card--left {
+        margin-right: 0;
+    }
+
+    .card--left img {
+        width: 54rem;
+        height: 36rem;
+    }
+
+    .card--right {
+        width: 54rem;
+    }
+} */
+@media only screen 
+  and (min-device-width: 375px) 
+  and (max-device-width: 812px) 
+  and (-webkit-min-device-pixel-ratio: 3) { 
+    * {
+        font-size: 35%;
     }
     
     .card{

--- a/src/style.css
+++ b/src/style.css
@@ -197,8 +197,8 @@ nav {
     }
 } */
 @media only screen 
-  and (min-width: 375px) 
-  and (max-width: 812px) 
+  and (min-width: 360px) 
+  /* and (max-width: 812px)  */
   and (-webkit-min-device-pixel-ratio: 2) { 
     * {
         font-size: 35%;

--- a/src/style.css
+++ b/src/style.css
@@ -14,7 +14,7 @@ body {
 }
 
 nav {
-    height: 0.08 vh;
+    height: 3rem;
     background-color: #F55A5A;
     display: flex;
     align-items: center;

--- a/src/style.css
+++ b/src/style.css
@@ -199,7 +199,7 @@ nav {
 @media only screen 
   and (min-width: 360px) 
   /* and (max-width: 812px)  */
-  and (-webkit-min-device-pixel-ratio: 2) { 
+  and (-webkit-min-device-pixel-ratio: 3) { 
     * {
         font-size: 35%;
     }

--- a/src/style.css
+++ b/src/style.css
@@ -9,9 +9,9 @@ body {
     font-family: 'Inter', sans-serif;
 }
 
-.app{
+/* .app{
     width: 100%;
-}
+} */
 
 nav {
     height: 3rem;

--- a/src/style.css
+++ b/src/style.css
@@ -197,8 +197,8 @@ nav {
     }
 } */
 @media only screen 
-  and (min-device-width: 375px) 
-  and (max-device-width: 812px) 
+  and (min-width: 375px) 
+  and (max-width: 812px) 
   and (-webkit-min-device-pixel-ratio: 3) { 
     * {
         font-size: 35%;

--- a/src/style.css
+++ b/src/style.css
@@ -9,12 +9,12 @@ body {
     font-family: 'Inter', sans-serif;
 }
 
-/* .app{
+.app{
     width: 100%;
-} */
+}
 
 nav {
-    height: 3rem;
+    height: 0.08 vh;
     background-color: #F55A5A;
     display: flex;
     align-items: center;
@@ -103,13 +103,13 @@ nav {
 }
 
 /* fit for different screens size */
-/* @media only screen and (min-width: 1024px) {
+@media screen and (min-width: 1024px) {
     * {
         font-size: 100%;
     }
 }
 
-@media only screen and (max-width: 924px) {
+@media screen and (max-width: 924px) {
     .card{
         flex-direction: column;
     }
@@ -128,7 +128,7 @@ nav {
     }
 }
 
-@media only screen and (max-width: 540px) {
+@media screen and (max-width: 540px) {
     * {
         font-size: 40%;
     }
@@ -137,7 +137,7 @@ nav {
         flex-direction: column;
     }
 
-    .card--left {
+    /* .card--left {
         margin-right: 0;
     }
 
@@ -148,10 +148,20 @@ nav {
 
     .card--right {
         width: 54rem;
+    } */
+
+    .card--left,.card--right {
+        width: 90%;
+        margin: 0 auto;
+    }
+
+    .card--left img {
+        width: 100%;
+        height: 75%;
     }
 }
 
-@media only screen and (max-width: 375px) {
+@media screen and (max-width: 375px) {
     * {
         font-size: 35%;
     }
@@ -160,7 +170,7 @@ nav {
         flex-direction: column;
     }
 
-    .card--left {
+    /* .card--left {
         margin-right: 0;
     }
 
@@ -171,10 +181,20 @@ nav {
 
     .card--right {
         width: 54rem;
+    } */
+
+    .card--left,.card--right {
+        width: 90%;
+        margin: 0 auto;
+    }
+
+    .card--left img {
+        width: 100%;
+        height: 75%;
     }
 }
 
-@media only screen and (max-width: 280px) {
+@media screen and (max-width: 280px) {
     * {
         font-size: 30%;
     }
@@ -183,7 +203,7 @@ nav {
         flex-direction: column;
     }
 
-    .card--left {
+    /* .card--left {
         margin-right: 0;
     }
 
@@ -194,53 +214,15 @@ nav {
 
     .card--right {
         width: 54rem;
-    }
-} */
-@media only screen 
-  and (min-width: 22em) 
-  /* and (max-width: 812px)  */
-  and (-webkit-min-device-pixel-ratio: 2) { 
-    * {
-        font-size: 35%;
-    }
-    
-    .card{
-        flex-direction: column;
-    }
+    } */
 
-    .card--left {
-        margin-right: 0;
+    .card--left,.card--right {
+        width: 90%;
+        margin: 0 auto;
     }
 
     .card--left img {
-        width: 54rem;
-        height: 36rem;
-    }
-
-    .card--right {
-        width: 54rem;
+        width: 100%;
+        height: 75%;
     }
 }
-
-/* @media only screen and (max-width: 375px) {
-    * {
-        font-size: 35%;
-    }
-    
-    .card{
-        flex-direction: column;
-    }
-
-    .card--left {
-        margin-right: 0;
-    }
-
-    .card--left img {
-        width: 54rem;
-        height: 36rem;
-    }
-
-    .card--right {
-        width: 54rem;
-    }
-} */

--- a/src/style.css
+++ b/src/style.css
@@ -153,7 +153,7 @@ nav {
 
  */
 
-@media screen and (max-width: 280px) {
+/* @media screen and (max-width: 280px) {
     * {
         font-size: 30%;
     }
@@ -197,4 +197,4 @@ nav {
     .card--right {
         width: 54rem;
     }
-}
+} */

--- a/src/style.css
+++ b/src/style.css
@@ -197,9 +197,9 @@ nav {
     }
 } */
 @media only screen 
-  and (min-width: 360px) 
+  and (min-width: 22em) 
   /* and (max-width: 812px)  */
-  and (-webkit-min-device-pixel-ratio: 3) { 
+  and (-webkit-min-device-pixel-ratio: 2) { 
     * {
         font-size: 35%;
     }

--- a/src/style.css
+++ b/src/style.css
@@ -103,28 +103,67 @@ nav {
 }
 
 /* fit for different screens size */
-@media screen and (min-width: 1024px) {
+@media screen and (max-width: 2560px) {
     * {
-        font-size: 100%;
+        font-size: 120%;
+    }
+}
+
+@media screen and (max-width: 1920px) {
+    * {
+        font-size: 105%;
+    }
+}
+
+@media screen and (max-width: 1366px) {
+    * {
+        font-size: 85%;
+    }
+}
+
+@media screen and (max-width: 1024px) {
+    * {
+        font-size: 80%;
     }
 }
 
 @media screen and (max-width: 924px) {
+    * {
+        font-size: 50%;
+    }
+    
     .card{
         flex-direction: column;
     }
 
-    .card--left {
-        margin-right: 0;
+    .card--left,.card--right {
+        width: 75%;
+        margin: 0 auto;
     }
 
     .card--left img {
-        width: 54rem;
-        height: 36rem;
+        width: 100%;
+        height: 75%;
+    }
+}
+
+@media screen and (max-width: 700px) {
+    * {
+        font-size: 45%;
+    }
+    
+    .card{
+        flex-direction: column;
     }
 
-    .card--right {
-        width: 54rem;
+    .card--left,.card--right {
+        width: 75%;
+        margin: 0 auto;
+    }
+
+    .card--left img {
+        width: 100%;
+        height: 75%;
     }
 }
 
@@ -137,21 +176,8 @@ nav {
         flex-direction: column;
     }
 
-    /* .card--left {
-        margin-right: 0;
-    }
-
-    .card--left img {
-        width: 54rem;
-        height: 36rem;
-    }
-
-    .card--right {
-        width: 54rem;
-    } */
-
     .card--left,.card--right {
-        width: 90%;
+        width: 75%;
         margin: 0 auto;
     }
 
@@ -170,21 +196,8 @@ nav {
         flex-direction: column;
     }
 
-    /* .card--left {
-        margin-right: 0;
-    }
-
-    .card--left img {
-        width: 54rem;
-        height: 36rem;
-    }
-
-    .card--right {
-        width: 54rem;
-    } */
-
     .card--left,.card--right {
-        width: 90%;
+        width: 75%;
         margin: 0 auto;
     }
 
@@ -203,21 +216,8 @@ nav {
         flex-direction: column;
     }
 
-    /* .card--left {
-        margin-right: 0;
-    }
-
-    .card--left img {
-        width: 54rem;
-        height: 36rem;
-    }
-
-    .card--right {
-        width: 54rem;
-    } */
-
     .card--left,.card--right {
-        width: 90%;
+        width: 75%;
         margin: 0 auto;
     }
 


### PR DESCRIPTION
**Problem:** Styling was broken on the actual mobile devices even though the browser simulations were perfect.
**Reason:** The use of `rem` unit made the size of image way wider than the actual mobile screen size.
**Fix:** Using the `%` unit instead.

```
@media screen and (max-width: 375px) {
    * {
        font-size: 35%;
    }
    
    .card{
        flex-direction: column;
    }

    /* .card--left {
        margin-right: 0;
    }

    .card--left img {
        width: 54rem;
        height: 36rem;
    }

    .card--right {
        width: 54rem;
    } */

    .card--left,.card--right {
        width: 90%;
        margin: 0 auto;
    }

    .card--left img {
        width: 100%;
        height: 75%;
    }
}
```